### PR TITLE
Update pitch.kdeplot to use KDEpy and include reflection method at boundaries

### DIFF
--- a/mplsoccer/pitch.py
+++ b/mplsoccer/pitch.py
@@ -1019,10 +1019,10 @@ class Pitch(object):
         scott_bw = [n ** (-1 / 6) * np.std(x), n ** (-1 / 6) * np.std(y)]
         # estimate KDE (including reflected data)
         grid, values = FFTKDE(bw=scott_bw).fit(np.c_[reflected_data_x, reflected_data_y]).evaluate(512)
-        x, y = np.unique(grid[:, 0]), np.unique(grid[:, 1])
+        x_grid, y_grid = np.unique(grid[:, 0]), np.unique(grid[:, 1])
         z = values.reshape(512, 512)
         # set up a bilinear interpolator to estimate density off the FFT grid
-        player_density = RectBivariateSpline(x, y, z, kx=1, ky=1)
+        player_density = RectBivariateSpline(x_grid, y_grid, z, kx=1, ky=1)
         # define points at which to evaluate the density
         x_pts = np.linspace(x_limits[0], x_limits[1], 100)
         y_pts = np.linspace(y_limits[0], y_limits[1], 100)

--- a/mplsoccer/pitch.py
+++ b/mplsoccer/pitch.py
@@ -9,7 +9,6 @@ import matplotlib.pyplot as plt
 import matplotlib.markers as mmarkers
 import numpy as np
 import seaborn as sns
-from KDEpy import FFTKDE
 from matplotlib.collections import LineCollection, PatchCollection
 from matplotlib.legend_handler import HandlerLineCollection, HandlerPathCollection, HandlerLine2D
 from matplotlib.cm import get_cmap
@@ -19,6 +18,8 @@ from matplotlib.legend import Legend
 from scipy.stats import binned_statistic_2d
 from scipy.spatial import Voronoi
 from scipy.stats import circmean
+from KDEpy import FFTKDE
+from scipy.interpolate import RectBivariateSpline
 from .scatterutils import football_hexagon_marker, football_pentagon_marker, _mscatter
 from collections import Sequence, namedtuple
 import warnings

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ seaborn
 scipy
 pandas
 beautifulsoup4
+KDEpy

--- a/setup.py
+++ b/setup.py
@@ -31,4 +31,5 @@ install_requires = ['matplotlib',
                     'seaborn',
                     'scipy',
                     'pandas',
-                    'numpy']
+                    'numpy',
+                    'KDEpy']


### PR DESCRIPTION
Should still work with the kdeplot example as-is. Added an additional argument to give the option of filled contour plots, may be worth adding a section to the example to show how that works (just requires changing the line_zorder when setting up the pitch)?