### PR TITLE
feat: Add Speedometer class for gauge/speedometer charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+:rocket: Version 1.6.2
+----------------------
+
+### Added
+* :icecream: Added ``Speedometer`` class for plotting speedometer/gauge charts \
+to visualize player speed metrics and performance indicators. \
+Inspired by @znstrider's [speedo library](https://github.com/znstrider/speedo). \
+Contributed by @PGupta-Git.
+
 :rocket: Version 1.6.1
 ----------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,13 +17,14 @@ import os
 import sys
 import mplsoccer
 import warnings
-sys.path.insert(0, os.path.abspath('.'))
+
+sys.path.insert(0, os.path.abspath("."))
 
 # -- Project information -----------------------------------------------------
 
-project = 'mplsoccer'
-copyright = '2025, Anmol Durgapal & Andrew Rowlinson'
-author = 'Anmol Durgapal & Andrew Rowlinson'
+project = "mplsoccer"
+copyright = "2025, Anmol Durgapal & Andrew Rowlinson"
+author = "Anmol Durgapal & Andrew Rowlinson"
 
 # The full version, including alpha/beta/rc tags
 VERSION = mplsoccer.__version__
@@ -35,17 +36,19 @@ release = VERSION
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc',
-              'sphinx.ext.autosummary',
-              'sphinx.ext.imgmath',
-              'sphinx.ext.viewcode',
-              'sphinx_gallery.gen_gallery',
-              'sphinx.ext.autosectionlabel',
-              'sphinx.ext.napoleon',
-              'numpydoc']
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.imgmath",
+    "sphinx.ext.viewcode",
+    "sphinx_gallery.gen_gallery",
+    "sphinx.ext.autosectionlabel",
+    "sphinx.ext.napoleon",
+    "numpydoc",
+]
 
 # https://github.com/readthedocs/readthedocs.org/issues/2569
-master_doc = 'index'
+master_doc = "index"
 
 # this is needed for some reason...
 # see https://github.com/numpy/numpydoc/issues/69
@@ -59,44 +62,53 @@ napoleon_use_admonition_for_examples = True
 # generate autosummary even if no references
 autosummary_generate = True
 # order api docs by order they appear in the code
-autodoc_member_order = 'bysource'
+autodoc_member_order = "bysource"
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build']
+exclude_patterns = ["_build"]
 
 # sphinx gallery
 sphinx_gallery_conf = {
-    'examples_dirs': ['../../examples'],
-    'gallery_dirs': ['gallery'],
-	'image_scrapers': ('matplotlib'),
-    'matplotlib_animations': True,
-	'within_subsection_order': ExampleTitleSortKey,
-    'subsection_order': ExplicitOrder(['../../examples/radar',
-                                       '../../examples/pizza_plots',
-                                       '../../examples/bumpy_charts',
-									   '../../examples/pitch_plots',
-									   '../../examples/sonars',
-									   '../../examples/tutorials',
-                                       '../../examples/statsbomb',
-                                       '../../examples/pitch_setup', ])}
+    "examples_dirs": ["../../examples"],
+    "gallery_dirs": ["gallery"],
+    "image_scrapers": ("matplotlib"),
+    "matplotlib_animations": True,
+    "within_subsection_order": ExampleTitleSortKey,
+    "subsection_order": ExplicitOrder(
+        [
+            "../../examples/radar",
+            "../../examples/pizza_plots",
+            "../../examples/bumpy_charts",
+            "../../examples/pitch_plots",
+            "../../examples/speedometer",
+            "../../examples/sonars",
+            "../../examples/tutorials",
+            "../../examples/statsbomb",
+            "../../examples/pitch_setup",
+        ]
+    ),
+}
 
 
 # filter warning messages
-warnings.filterwarnings("ignore", category=UserWarning,
-                        message='Matplotlib is currently using agg, which is a'
-                                ' non-GUI backend, so cannot show the figure.')
+warnings.filterwarnings(
+    "ignore",
+    category=UserWarning,
+    message="Matplotlib is currently using agg, which is a"
+    " non-GUI backend, so cannot show the figure.",
+)
 
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -105,5 +117,4 @@ html_static_path = []
 
 # add logo
 html_logo = "logo-white.png"
-html_theme_options = {'logo_only': True,
-                      'display_version': False}
+html_theme_options = {"logo_only": True, "display_version": False}

--- a/examples/pitch_plots/plot_formations.py
+++ b/examples/pitch_plots/plot_formations.py
@@ -20,6 +20,7 @@ The formations can be plotted as various options by using the ``kind`` argument:
 
 * ``kind='text'``
 """
+
 import math
 from urllib.request import urlopen, Request
 
@@ -34,9 +35,9 @@ from mplsoccer import VerticalPitch, Sbopen, FontManager, inset_image
 # data parser, fonts and path effects for giving the font an edge
 parser = Sbopen()
 roboto_bold = FontManager(
-    'https://raw.githubusercontent.com/google/fonts/main/apache/robotoslab/RobotoSlab%5Bwght%5D.ttf')
-path_eff = [path_effects.Stroke(linewidth=3, foreground='white'),
-            path_effects.Normal()]
+    "https://raw.githubusercontent.com/google/fonts/main/apache/robotoslab/RobotoSlab%5Bwght%5D.ttf"
+)
+path_eff = [path_effects.Stroke(linewidth=3, foreground="white"), path_effects.Normal()]
 
 ##############################################################################
 # Load StatsBomb data
@@ -47,54 +48,104 @@ path_eff = [path_effects.Stroke(linewidth=3, foreground='white'),
 parser = Sbopen()
 event, related, freeze, tactics = parser.event(69249)
 # starting players from Barcelona
-starting_xi_event = event.loc[((event['type_name'] == 'Starting XI') &
-                               (event['team_name'] == 'Barcelona')), ['id', 'tactics_formation']]
+starting_xi_event = event.loc[
+    ((event["type_name"] == "Starting XI") & (event["team_name"] == "Barcelona")),
+    ["id", "tactics_formation"],
+]
 # joining on the team name and formation to the lineup
-starting_xi = tactics.merge(starting_xi_event, on='id')
+starting_xi = tactics.merge(starting_xi_event, on="id")
 # replace player names with the shorter version
-player_short_names = {'Víctor Valdés Arribas': 'Víctor Valdés',
-                      'Daniel Alves da Silva': 'Dani Alves',
-                      'Gerard Piqué Bernabéu': 'Gerard Piqué',
-                      'Carles Puyol i Saforcada': 'Carles Puyol',
-                      'Eric-Sylvain Bilal Abidal': 'Eric Abidal',
-                      'Gnégnéri Yaya Touré': 'Yaya Touré',
-                      'Andrés Iniesta Luján': 'Andrés Iniesta',
-                      'Xavier Hernández Creus': 'Xavier Hernández',
-                      'Lionel Andrés Messi Cuccittini': 'Lionel Messi',
-                      'Thierry Henry': 'Thierry Henry',
-                      "Samuel Eto''o Fils": "Samuel Eto'o"}
-starting_xi['player_name'] = starting_xi['player_name'].replace(player_short_names)
+player_short_names = {
+    "Víctor Valdés Arribas": "Víctor Valdés",
+    "Daniel Alves da Silva": "Dani Alves",
+    "Gerard Piqué Bernabéu": "Gerard Piqué",
+    "Carles Puyol i Saforcada": "Carles Puyol",
+    "Eric-Sylvain Bilal Abidal": "Eric Abidal",
+    "Gnégnéri Yaya Touré": "Yaya Touré",
+    "Andrés Iniesta Luján": "Andrés Iniesta",
+    "Xavier Hernández Creus": "Xavier Hernández",
+    "Lionel Andrés Messi Cuccittini": "Lionel Messi",
+    "Thierry Henry": "Thierry Henry",
+    "Samuel Eto''o Fils": "Samuel Eto'o",
+}
+starting_xi["player_name"] = starting_xi["player_name"].replace(player_short_names)
 # filter only succesful ball receipts from the starting XI
-event = event.loc[((event['type_name'] == 'Ball Receipt') &
-                   (event['outcome_name'].isnull()) &
-                   (event['player_id'].isin(starting_xi['player_id']))
-                   ), ['player_id', 'x', 'y']]
+event = event.loc[
+    (
+        (event["type_name"] == "Ball Receipt")
+        & (event["outcome_name"].isnull())
+        & (event["player_id"].isin(starting_xi["player_id"]))
+    ),
+    ["player_id", "x", "y"],
+]
 # merge on the starting positions to the events
-event = event.merge(starting_xi, on='player_id')
-formation = event['tactics_formation'].iloc[0]
+event = event.merge(starting_xi, on="player_id")
+formation = event["tactics_formation"].iloc[0]
 
 ##############################################################################
 # Flip and half
 # -------------
 # You can plot the formations in different configurations using the ``flip`` and ``half`` arguments.
-pitch = VerticalPitch(line_alpha=0.5, goal_type='box', goal_alpha=0.5)
+pitch = VerticalPitch(line_alpha=0.5, goal_type="box", goal_alpha=0.5)
 fig, ax = pitch.draw(ncols=3, figsize=(13, 9))
-sc_full = pitch.formation(formation, positions=starting_xi.position_id, c='#053e7a', ax=ax[0])
-sc_flip = pitch.formation(formation, positions=starting_xi.position_id, c='#01453e', flip=True,
-                          ax=ax[1])
-sc_half = pitch.formation(formation, positions=starting_xi.position_id, c='#ad1f4a', half=True,
-                          ax=ax[2])
-sc_half_flip = pitch.formation(formation, positions=starting_xi.position_id, kind='scatter',
-                               flip=True, half=True, ax=ax[2])
+sc_full = pitch.formation(
+    formation, positions=starting_xi.position_id, c="#053e7a", ax=ax[0]
+)
+sc_flip = pitch.formation(
+    formation, positions=starting_xi.position_id, c="#01453e", flip=True, ax=ax[1]
+)
+sc_half = pitch.formation(
+    formation, positions=starting_xi.position_id, c="#ad1f4a", half=True, ax=ax[2]
+)
+sc_half_flip = pitch.formation(
+    formation,
+    positions=starting_xi.position_id,
+    kind="scatter",
+    flip=True,
+    half=True,
+    ax=ax[2],
+)
 
-txt_full = pitch.text(60, 40, 'flip=False\nhalf=False', ax=ax[0], va='center', ha='center',
-                      color='#053e7a', fontsize=20)
-txt_flip = pitch.text(60, 40, 'flip=True\nhalf=False', ax=ax[1], va='center', ha='center',
-                      color='#01453e', fontsize=20)
-txt_half = pitch.text(45, 40, 'flip=False\nhalf=True', ax=ax[2], va='center', ha='center',
-                      color='#ad1f4a', fontsize=20)
-txt_half_flip = pitch.text(75, 40, 'flip=True\nhalf=True', ax=ax[2], va='center', ha='center',
-                           color='#9d49c7', fontsize=20)
+txt_full = pitch.text(
+    60,
+    40,
+    "flip=False\nhalf=False",
+    ax=ax[0],
+    va="center",
+    ha="center",
+    color="#053e7a",
+    fontsize=20,
+)
+txt_flip = pitch.text(
+    60,
+    40,
+    "flip=True\nhalf=False",
+    ax=ax[1],
+    va="center",
+    ha="center",
+    color="#01453e",
+    fontsize=20,
+)
+txt_half = pitch.text(
+    45,
+    40,
+    "flip=False\nhalf=True",
+    ax=ax[2],
+    va="center",
+    ha="center",
+    color="#ad1f4a",
+    fontsize=20,
+)
+txt_half_flip = pitch.text(
+    75,
+    40,
+    "flip=True\nhalf=True",
+    ax=ax[2],
+    va="center",
+    ha="center",
+    color="#9d49c7",
+    fontsize=20,
+)
 
 ##############################################################################
 # Get images
@@ -104,42 +155,42 @@ txt_half_flip = pitch.text(75, 40, 'flip=True\nhalf=True', ax=ax[2], va='center'
 image_urls = {
     # Credit: Darz Mol. Creative Commons Attribution-Share Alike 2.5 Spain license.
     # https://en.wikipedia.org/wiki/V%C3%ADctor_Vald%C3%A9s#/media/File:Victor_Valdes_15abr2007.jpg
-    'Víctor Valdés': 'https://upload.wikimedia.org/wikipedia/commons/4/46/Victor_Valdes_15abr2007.jpg',
+    "Víctor Valdés": "https://upload.wikimedia.org/wikipedia/commons/4/46/Victor_Valdes_15abr2007.jpg",
     # Credit: Football.ua. CC BY-SA 3.0
     # https://en.wikipedia.org/wiki/Dani_Alves#/media/File:2015_UEFA_Super_Cup_107.jpg
-    'Dani Alves': 'https://upload.wikimedia.org/wikipedia/commons/1/1f/2015_UEFA_Super_Cup_107.jpg',
+    "Dani Alves": "https://upload.wikimedia.org/wikipedia/commons/1/1f/2015_UEFA_Super_Cup_107.jpg",
     # Credit: Shay. CC BY-SA 3.0
     # https://en.wikipedia.org/wiki/Gerard_Piqu%C3%A9#/media/File:Gerard_Pique.jpg
-    'Gerard Piqué': 'https://upload.wikimedia.org/wikipedia/commons/e/e1/Gerard_Pique.jpg',
+    "Gerard Piqué": "https://upload.wikimedia.org/wikipedia/commons/e/e1/Gerard_Pique.jpg",
     # Credit: Shay. CC BY-SA 3.0
     # https://en.wikipedia.org/wiki/Carles_Puyol#/media/File:Carles_Puyol_Joan_Gamper-Tr.jpg
-    'Carles Puyol': 'https://upload.wikimedia.org/wikipedia/commons/6/60/Carles_Puyol_Joan_Gamper-Tr.jpg',
+    "Carles Puyol": "https://upload.wikimedia.org/wikipedia/commons/6/60/Carles_Puyol_Joan_Gamper-Tr.jpg",
     # Credit: Mutari. Public Domain
     # https://en.wikipedia.org/wiki/Eric_Abidal#/media/File:%C3%89ric_Abidal_-_001.jpg
-    'Eric Abidal': 'https://upload.wikimedia.org/wikipedia/commons/c/c8/%C3%89ric_Abidal_-_001.jpg',
+    "Eric Abidal": "https://upload.wikimedia.org/wikipedia/commons/c/c8/%C3%89ric_Abidal_-_001.jpg",
     # Credit: Football.ua. CC BY-SA 3.0
     # https://en.wikipedia.org/wiki/Yaya_Tour%C3%A9#/media/File:Yaya_Tour%C3%A9.JPG
-    'Yaya Touré': 'https://upload.wikimedia.org/wikipedia/commons/e/ee/Yaya_Tour%C3%A9.JPG',
+    "Yaya Touré": "https://upload.wikimedia.org/wikipedia/commons/e/ee/Yaya_Tour%C3%A9.JPG",
     # Credit: Darz Mol CC BY-SA 2.5 es
     # https://en.wikipedia.org/wiki/Andr%C3%A9s_Iniesta#/media/File:Andr%C3%A9s_Iniesta_21dec2006.jpg
-    'Andrés Iniesta': 'https://upload.wikimedia.org/wikipedia/commons/e/ed/Andr%C3%A9s_Iniesta_21dec2006.jpg',
+    "Andrés Iniesta": "https://upload.wikimedia.org/wikipedia/commons/e/ed/Andr%C3%A9s_Iniesta_21dec2006.jpg",
     # Credit: Castroquini. CC BY-SA 3.0
     # https://en.wikipedia.org/wiki/Xavi#/media/File:2012_2013_-_06_Xavi_Hern%C3%A1ndez.jpg
-    'Xavier Hernández': 'https://upload.wikimedia.org/wikipedia/commons/9/93/2012_2013_-_06_Xavi_Hern%C3%A1ndez.jpg',
+    "Xavier Hernández": "https://upload.wikimedia.org/wikipedia/commons/9/93/2012_2013_-_06_Xavi_Hern%C3%A1ndez.jpg",
     # Credit: Tasnim News Agency. CC BY 4.0
     # https://fi.wikipedia.org/wiki/Lionel_Messi#/media/Tiedosto:Lionel-Messi-Argentina-2022-FIFA-World-Cup_(cropped).jpg
-    'Lionel Messi': 'https://upload.wikimedia.org/wikipedia/commons/b/b4/Lionel-Messi-Argentina-2022-FIFA-World-Cup_%28cropped%29.jpg',
+    "Lionel Messi": "https://upload.wikimedia.org/wikipedia/commons/b/b4/Lionel-Messi-Argentina-2022-FIFA-World-Cup_%28cropped%29.jpg",
     # Credit: Shay. CC BY-SA 3.0
     # https://en.wikipedia.org/wiki/Thierry_Henry#/media/File:Thierry_Henry_2008.jpg
-    'Thierry Henry': 'https://upload.wikimedia.org/wikipedia/commons/6/6e/Thierry_Henry_2008.jpg',
+    "Thierry Henry": "https://upload.wikimedia.org/wikipedia/commons/6/6e/Thierry_Henry_2008.jpg",
     # Credit: Shay. CC BY-SA 3.0
     # https://en.wikipedia.org/wiki/Samuel_Eto%27o#/media/File:Etoo_Joan_Gamper_Trophy_2008.jpg
-    "Samuel Eto'o": 'https://upload.wikimedia.org/wikipedia/commons/7/77/Etoo_Joan_Gamper_Trophy_2008.jpg',
+    "Samuel Eto'o": "https://upload.wikimedia.org/wikipedia/commons/7/77/Etoo_Joan_Gamper_Trophy_2008.jpg",
 }
 images = []
 for url in starting_xi.player_name.map(image_urls):
     request = Request(url)
-    request.add_header('User-Agent', 'mplsoccerdocs (https://mplsoccer.rtfd.io)')
+    request.add_header("User-Agent", "mplsoccerdocs (https://mplsoccer.rtfd.io)")
     images.append(Image.open(urlopen(request)))
 
 ##############################################################################
@@ -149,15 +200,20 @@ for url in starting_xi.player_name.map(image_urls):
 # Here we use xoffset and yoffset to eliminate some overlapping images.
 # The offsets should be in the same order as the positions argument (i.e. player identifiers).
 # Additional keyword arguments are passed on to Axes.imshow.
-pitch = VerticalPitch(goal_type='box')
+pitch = VerticalPitch(goal_type="box")
 fig, ax = pitch.draw(figsize=(6, 8.72))
-ax_image = pitch.formation(formation, positions=starting_xi.position_id, kind='image', image=images,
-                           width=14,
-                           xoffset=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -5],
-                           # xoffset in same order as the positions
-                           yoffset=[0, 2, 5, -5, -2, 0, 0, 0, 0, 0, 0],
-                           # yoffset in the same order as the positions
-                           ax=ax)
+ax_image = pitch.formation(
+    formation,
+    positions=starting_xi.position_id,
+    kind="image",
+    image=images,
+    width=14,
+    xoffset=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -5],
+    # xoffset in same order as the positions
+    yoffset=[0, 2, 5, -5, -2, 0, 0, 0, 0, 0, 0],
+    # yoffset in the same order as the positions
+    ax=ax,
+)
 # comment below sets this as the thumbnail in the docs
 # sphinx_gallery_thumbnail_path = 'gallery/pitch_plots/images/sphx_glr_plot_formations_002'
 
@@ -168,20 +224,34 @@ ax_image = pitch.formation(formation, positions=starting_xi.position_id, kind='i
 # Additional keyword arguments are passed on to Axes.text.
 # Here we also plot ``kind='scatter'`` to add a marker for each position and additional
 # arguments are passed on to Axes.scatter.
-pitch = VerticalPitch(goal_type='box')
+pitch = VerticalPitch(goal_type="box")
 fig, ax = pitch.draw(figsize=(6, 8.72))
-ax_text = pitch.formation(formation, positions=starting_xi.position_id, kind='text',
-                          text=starting_xi.player_name.str.replace(' ', '\n'),
-                          va='center', ha='center', fontsize=16, ax=ax)
+ax_text = pitch.formation(
+    formation,
+    positions=starting_xi.position_id,
+    kind="text",
+    text=starting_xi.player_name.str.replace(" ", "\n"),
+    va="center",
+    ha="center",
+    fontsize=16,
+    ax=ax,
+)
 # scatter markers
-mpl.rcParams['hatch.linewidth'] = 3
-mpl.rcParams['hatch.color'] = '#a50044'
-ax_scatter = pitch.formation(formation, positions=starting_xi.position_id, kind='scatter',
-                             c='#004d98', hatch='||', linewidth=3, s=500,
-                             # you can also provide a single offset instead of a list
-                             # for xoffset and yoffset
-                             xoffset=-8,
-                             ax=ax)
+mpl.rcParams["hatch.linewidth"] = 3
+mpl.rcParams["hatch.color"] = "#a50044"
+ax_scatter = pitch.formation(
+    formation,
+    positions=starting_xi.position_id,
+    kind="scatter",
+    c="#004d98",
+    hatch="||",
+    linewidth=3,
+    s=500,
+    # you can also provide a single offset instead of a list
+    # for xoffset and yoffset
+    xoffset=-8,
+    ax=ax,
+)
 
 ##############################################################################
 # Pitch of pitches
@@ -194,57 +264,97 @@ ax_scatter = pitch.formation(formation, positions=starting_xi.position_id, kind=
 # In this example, it is the first game that Messi played as a false-nine.
 # After around 7 minutes Eto'o" and Messi switched
 # positions, which is why their heatmaps look the wrong way around.
-pitch = VerticalPitch(goal_type='box')
-fig, axs = pitch.grid(endnote_height=0, title_height=0.08, figheight=14, grid_width=0.9,
-                      grid_height=0.9, axis=False)
-fm_rubik = FontManager('https://raw.githubusercontent.com/google/fonts/main/ofl/'
-                       'rubikmonoone/RubikMonoOne-Regular.ttf')
-title = axs['title'].text(0.5, 0.5, 'Pass receptions\nBarcelona vs. Real Madrid', fontsize=25,
-                          va='center',
-                          ha='center', color='#161616', fontproperties=fm_rubik.prop)
+pitch = VerticalPitch(goal_type="box")
+fig, axs = pitch.grid(
+    endnote_height=0,
+    title_height=0.08,
+    figheight=14,
+    grid_width=0.9,
+    grid_height=0.9,
+    axis=False,
+)
+fm_rubik = FontManager(
+    "https://raw.githubusercontent.com/google/fonts/main/ofl/"
+    "rubikmonoone/RubikMonoOne-Regular.ttf"
+)
+title = axs["title"].text(
+    0.5,
+    0.5,
+    "Pass receptions\nBarcelona vs. Real Madrid",
+    fontsize=25,
+    va="center",
+    ha="center",
+    color="#161616",
+    fontproperties=fm_rubik.prop,
+)
 
-pitch_ax = pitch.formation(formation,
-                           kind='pitch',
-                           # avoid overlapping pitches with offsets
-                           xoffset=[-3, 6, 6, 6, 6, 14, 0, 0, 0, 0, 0],
-                           # pitch is 23 units long (could also set the height).
-                           # note this is set assuming the pitch is horizontal, but in this example
-                           # it is vertical so that you get the same results
-                           # from both VerticalPitch and Pitch
-                           width=23,
-                           positions=starting_xi['position_id'],
-                           ax=axs['pitch'],
-                           # additional arguments temporarily amend the pitch appearance
-                           # note we are plotting a really faint positional grid
-                           # that overlays the kdeplot
-                           linewidth=0.5,
-                           pitch_color='None',
-                           line_zorder=3,
-                           line_color='black',
-                           positional=True,
-                           positional_zorder=3,
-                           positional_linewidth=1,
-                           positional_alpha=0.3,
-                           )
+pitch_ax = pitch.formation(
+    formation,
+    kind="pitch",
+    # avoid overlapping pitches with offsets
+    xoffset=[-3, 6, 6, 6, 6, 14, 0, 0, 0, 0, 0],
+    # pitch is 23 units long (could also set the height).
+    # note this is set assuming the pitch is horizontal, but in this example
+    # it is vertical so that you get the same results
+    # from both VerticalPitch and Pitch
+    width=23,
+    positions=starting_xi["position_id"],
+    ax=axs["pitch"],
+    # additional arguments temporarily amend the pitch appearance
+    # note we are plotting a really faint positional grid
+    # that overlays the kdeplot
+    linewidth=0.5,
+    pitch_color="None",
+    line_zorder=3,
+    line_color="black",
+    positional=True,
+    positional_zorder=3,
+    positional_linewidth=1,
+    positional_alpha=0.3,
+)
 
 # adding kdeplot and player titles
 for position in pitch_ax:
-    player_name = starting_xi[starting_xi['position_id'] == position].player_name.iloc[0]
-    player_name = player_name.replace(' ', '\n').replace('-', '-\n')
-    pitch.text(150, 40, player_name, va='top', ha='center', fontsize=15, ax=pitch_ax[position],
-               fontproperties=fm_rubik.prop, color='#353535')
-    pitch.kdeplot(x=event.loc[event['position_id'] == position, 'x'],
-                  y=event.loc[event['position_id'] == position, 'y'],
-                  fill=True, levels=100, cut=100, cmap='Blues', thresh=0, ax=pitch_ax[position])
+    player_name = starting_xi[starting_xi["position_id"] == position].player_name.iloc[
+        0
+    ]
+    player_name = player_name.replace(" ", "\n").replace("-", "-\n")
+    pitch.text(
+        150,
+        40,
+        player_name,
+        va="top",
+        ha="center",
+        fontsize=15,
+        ax=pitch_ax[position],
+        fontproperties=fm_rubik.prop,
+        color="#353535",
+    )
+    pitch.kdeplot(
+        x=event.loc[event["position_id"] == position, "x"],
+        y=event.loc[event["position_id"] == position, "y"],
+        fill=True,
+        levels=100,
+        cut=100,
+        cmap="Blues",
+        thresh=0,
+        ax=pitch_ax[position],
+    )
 
 ##############################################################################
 # Axes
 # ----
 # You can plot the formation as axes. Additional keyword arguments are passed on to Axes.inset_axes.
-pitch = VerticalPitch(goal_type='box')
+pitch = VerticalPitch(goal_type="box")
 fig, ax = pitch.draw(figsize=(6, 8.72))
-ax_text = pitch.formation(formation, positions=starting_xi.position_id, height=15, aspect=1,
-                          kind='axes', ax=ax)
+ax_text = pitch.formation(
+    formation,
+    positions=starting_xi.position_id,
+    height=15,
+    aspect=1,
+    kind="axes",
+    ax=ax,
+)
 
 ##############################################################################
 # Get Opta data
@@ -257,14 +367,47 @@ ax_text = pitch.formation(formation, positions=starting_xi.position_id, height=1
 # called '343' in Opta's data.
 totw_player_data = pd.DataFrame(
     {
-        'position': ['LW', 'ST', 'RW', 'LCM', 'CDM', 'RCM', 'LB', 'LCB', 'RCB', 'RB', 'GK'],
-        'position_id': [11, 9, 10, 8, 4, 7, 3, 6, 5, 2, 1],
-        'player': ['Reiten', 'Kerr', 'Fleming', 'Charles', 'Miedema', 'Kirby', 'Blundell',
-                   'Greenwood', 'Bryson', 'Battle', 'Earps'],
-        'score': [9.7, 8.6, 8.7, 9.1, 8.7, 9.5, 7.6, 8.0, 8.0, 9.1, 8.3],
-        'team': ['Chelsea', 'Chelsea', 'Chelsea', 'Chelsea', 'Arsenal', 'Chelsea',
-                 'Manchester United', 'Manchester City', 'Reading', 'Manchester United',
-                 'Manchester United']
+        "position": [
+            "LW",
+            "ST",
+            "RW",
+            "LCM",
+            "CDM",
+            "RCM",
+            "LB",
+            "LCB",
+            "RCB",
+            "RB",
+            "GK",
+        ],
+        "position_id": [11, 9, 10, 8, 4, 7, 3, 6, 5, 2, 1],
+        "player": [
+            "Reiten",
+            "Kerr",
+            "Fleming",
+            "Charles",
+            "Miedema",
+            "Kirby",
+            "Blundell",
+            "Greenwood",
+            "Bryson",
+            "Battle",
+            "Earps",
+        ],
+        "score": [9.7, 8.6, 8.7, 9.1, 8.7, 9.5, 7.6, 8.0, 8.0, 9.1, 8.3],
+        "team": [
+            "Chelsea",
+            "Chelsea",
+            "Chelsea",
+            "Chelsea",
+            "Arsenal",
+            "Chelsea",
+            "Manchester United",
+            "Manchester City",
+            "Reading",
+            "Manchester United",
+            "Manchester United",
+        ],
     }
 )
 totw_player_data
@@ -272,16 +415,16 @@ totw_player_data
 ##############################################################################
 # Get the club badges as a dictionary and turn it into a list of badges for each player.
 badge_urls = {
-    'Manchester United': 'https://upload.wikimedia.org/wikipedia/en/thumb/7/7a/Manchester_United_FC_crest.svg/250px-Manchester_United_FC_crest.svg.png',
-    'Chelsea': 'https://upload.wikimedia.org/wikipedia/en/thumb/c/cc/Chelsea_FC.svg/240px-Chelsea_FC.svg.png',
-    'Manchester City': 'https://upload.wikimedia.org/wikipedia/en/thumb/e/eb/Manchester_City_FC_badge.svg/250px-Manchester_City_FC_badge.svg.png',
-    'Reading': 'https://upload.wikimedia.org/wikipedia/en/thumb/1/11/Reading_FC.svg/240px-Reading_FC.svg.png',
-    'Arsenal': "https://upload.wikimedia.org/wikipedia/en/thumb/5/53/Arsenal_FC.svg/250px-Arsenal_FC.svg.png",
+    "Manchester United": "https://upload.wikimedia.org/wikipedia/en/thumb/7/7a/Manchester_United_FC_crest.svg/250px-Manchester_United_FC_crest.svg.png",
+    "Chelsea": "https://upload.wikimedia.org/wikipedia/en/thumb/c/cc/Chelsea_FC.svg/250px-Chelsea_FC.svg.png",
+    "Manchester City": "https://upload.wikimedia.org/wikipedia/en/thumb/e/eb/Manchester_City_FC_badge.svg/250px-Manchester_City_FC_badge.svg.png",
+    "Reading": "https://upload.wikimedia.org/wikipedia/en/thumb/1/11/Reading_FC.svg/250px-Reading_FC.svg.png",
+    "Arsenal": "https://upload.wikimedia.org/wikipedia/en/thumb/5/53/Arsenal_FC.svg/250px-Arsenal_FC.svg.png",
 }
 image_dict = {}
 for team, url in badge_urls.items():
     request = Request(url)
-    request.add_header('User-Agent', 'mplsoccerdocs (https://mplsoccer.rtfd.io)')
+    request.add_header("User-Agent", "mplsoccerdocs (https://mplsoccer.rtfd.io)")
     image_dict[team] = Image.open(urlopen(request))
 images = [image_dict[team] for team in totw_player_data.team]
 
@@ -293,29 +436,66 @@ images = [image_dict[team] for team in totw_player_data.team]
 # and use xoffsets to adjust the positions to avoid overlaps
 
 # setup figure
-pitch = VerticalPitch(pitch_type='opta', pitch_color='#333333', line_color='white', line_alpha=0.2,
-                      line_zorder=3)
-fig, axes = pitch.grid(endnote_height=0, figheight=13, title_height=0.1, title_space=0, space=0)
-fig.set_facecolor('#333333')
+pitch = VerticalPitch(
+    pitch_type="opta",
+    pitch_color="#333333",
+    line_color="white",
+    line_alpha=0.2,
+    line_zorder=3,
+)
+fig, axes = pitch.grid(
+    endnote_height=0, figheight=13, title_height=0.1, title_space=0, space=0
+)
+fig.set_facecolor("#333333")
 
 # title
-axes['title'].axis('off')
-axes['title'].text(0.5, 0.6, 'WSL Team of the Week', ha='center', va='center', color='white',
-                   fontsize=20)
-axes['title'].text(0.5, 0.3, 'Round 9', ha='center', va='center', color='white', fontsize=14)
-text_names = pitch.formation('433', kind='text', positions=totw_player_data.position_id,
-                             text=totw_player_data.player, ax=axes['pitch'],
-                             xoffset=-2,  # offset the player names from the centers
-                             ha='center', va='center', color='white', fontsize=11)
-text_scores = pitch.formation('433', kind='text', positions=totw_player_data.position_id,
-                              text=totw_player_data.score, ax=axes['pitch'],
-                              xoffset=-5,  # offset the scores from the centers
-                              ha='center', va='center', color='white', fontsize=11,
-                              bbox=dict(facecolor='green', boxstyle='round,pad=0.2', linewidth=0))
-badge_axes = pitch.formation('433', kind='image', positions=totw_player_data.position_id,
-                             image=images, height=10, ax=axes['pitch'],
-                             xoffset=5,  # offset the images from the centers
-                             )
+axes["title"].axis("off")
+axes["title"].text(
+    0.5,
+    0.6,
+    "WSL Team of the Week",
+    ha="center",
+    va="center",
+    color="white",
+    fontsize=20,
+)
+axes["title"].text(
+    0.5, 0.3, "Round 9", ha="center", va="center", color="white", fontsize=14
+)
+text_names = pitch.formation(
+    "433",
+    kind="text",
+    positions=totw_player_data.position_id,
+    text=totw_player_data.player,
+    ax=axes["pitch"],
+    xoffset=-2,  # offset the player names from the centers
+    ha="center",
+    va="center",
+    color="white",
+    fontsize=11,
+)
+text_scores = pitch.formation(
+    "433",
+    kind="text",
+    positions=totw_player_data.position_id,
+    text=totw_player_data.score,
+    ax=axes["pitch"],
+    xoffset=-5,  # offset the scores from the centers
+    ha="center",
+    va="center",
+    color="white",
+    fontsize=11,
+    bbox=dict(facecolor="green", boxstyle="round,pad=0.2", linewidth=0),
+)
+badge_axes = pitch.formation(
+    "433",
+    kind="image",
+    positions=totw_player_data.position_id,
+    image=images,
+    height=10,
+    ax=axes["pitch"],
+    xoffset=5,  # offset the images from the centers
+)
 
 ##############################################################################
 # Get Wyscout data
@@ -323,13 +503,35 @@ badge_axes = pitch.formation('433', kind='image', positions=totw_player_data.pos
 # The next example uses some example
 # `Wyscout data <https://www.hudl.com/blog/wyscout-analysis-chelsea-vs-manchester-united>`_.
 
-wyscout_data = {'player_name': ['David de Gea', 'Bailly', 'Maguire', 'Shaw',
-                                'Wan-Bissaka', 'Matić', 'Fred', 'Williams',
-                                'Bruno Fernandes', 'James', 'Martial'],
-                'position_id': ['gk', 'rcb3', 'cb', 'lcb3', 'rwb', 'rcmf', 'lcmf', 'lwb', 'amf',
-                                'ss', 'cf'],
-                }
-WYSCOUT_FORMATION = '3-4-1-2'
+wyscout_data = {
+    "player_name": [
+        "David de Gea",
+        "Bailly",
+        "Maguire",
+        "Shaw",
+        "Wan-Bissaka",
+        "Matić",
+        "Fred",
+        "Williams",
+        "Bruno Fernandes",
+        "James",
+        "Martial",
+    ],
+    "position_id": [
+        "gk",
+        "rcb3",
+        "cb",
+        "lcb3",
+        "rwb",
+        "rcmf",
+        "lcmf",
+        "lwb",
+        "amf",
+        "ss",
+        "cf",
+    ],
+}
+WYSCOUT_FORMATION = "3-4-1-2"
 df_wyscout = pd.DataFrame(wyscout_data)
 df_wyscout
 
@@ -340,21 +542,40 @@ df_wyscout
 # Note for some formations in the Wyscout data there are two attacking midfielders ('amf')
 # In mplsoccer, we have assigned the right position 'ramf' and the left position 'lamf'.
 # You may have to arbitrarily assign your 'amf' positions to these positions.
-pitch = VerticalPitch(pitch_type='wyscout', goal_type='box', pitch_color='#53ac5c',
-                      line_color='white', linewidth=3, corner_arcs=True)
+pitch = VerticalPitch(
+    pitch_type="wyscout",
+    goal_type="box",
+    pitch_color="#53ac5c",
+    line_color="white",
+    linewidth=3,
+    corner_arcs=True,
+)
 fig, ax = pitch.draw(figsize=(6, 8.72))
-sc_formation = pitch.formation(WYSCOUT_FORMATION, positions=wyscout_data['position_id'],
-                               ax=ax, c='#DA291C', ec='#FBE122',
-                               xoffset=[-6, -3, -3, -3, -5, -3, -3, -5, -5, -3, -3],
-                               yoffset=[0, 0, 0, 0, -5, 0, 0, 5, 0, 0, 0],
-                               lw=3, s=300)
-sc_text = pitch.formation(WYSCOUT_FORMATION, positions=wyscout_data['position_id'],
-                          text=df_wyscout['player_name'].str.replace(' ', '\n').str.replace('-',
-                                                                                            '\n'),
-                          yoffset=[0, 0, 0, 0, -5, 0, 0, 5, 0, 0, 0],
-                          kind='text', va='center', ha='center', xoffset=2,
-                          fontsize=20, fontproperties=roboto_bold.prop, path_effects=path_eff,
-                          ax=ax)
+sc_formation = pitch.formation(
+    WYSCOUT_FORMATION,
+    positions=wyscout_data["position_id"],
+    ax=ax,
+    c="#DA291C",
+    ec="#FBE122",
+    xoffset=[-6, -3, -3, -3, -5, -3, -3, -5, -5, -3, -3],
+    yoffset=[0, 0, 0, 0, -5, 0, 0, 5, 0, 0, 0],
+    lw=3,
+    s=300,
+)
+sc_text = pitch.formation(
+    WYSCOUT_FORMATION,
+    positions=wyscout_data["position_id"],
+    text=df_wyscout["player_name"].str.replace(" ", "\n").str.replace("-", "\n"),
+    yoffset=[0, 0, 0, 0, -5, 0, 0, 5, 0, 0, 0],
+    kind="text",
+    va="center",
+    ha="center",
+    xoffset=2,
+    fontsize=20,
+    fontproperties=roboto_bold.prop,
+    path_effects=path_eff,
+    ax=ax,
+)
 
 ##############################################################################
 # Valid formations
@@ -376,25 +597,40 @@ pitch.formations_dataframe
 # --------------------
 # Below is a showcase of all available formations and their positions.
 
-pitch = VerticalPitch('uefa', line_alpha=0.5, pitch_color='#53ac5c', line_color='white')
+pitch = VerticalPitch("uefa", line_alpha=0.5, pitch_color="#53ac5c", line_color="white")
 
 df_formations = pitch.formations_dataframe
 COLS = 5
 rows = math.ceil(len(pitch.formations) / COLS)
 
-fig, axes = pitch.grid(nrows=rows, ncols=COLS, title_height=0.015, endnote_height=0, figheight=50,
-                       space=0.08, grid_height=0.92)
-axes_p = axes['pitch'].flatten()
+fig, axes = pitch.grid(
+    nrows=rows,
+    ncols=COLS,
+    title_height=0.015,
+    endnote_height=0,
+    figheight=50,
+    space=0.08,
+    grid_height=0.92,
+)
+axes_p = axes["pitch"].flatten()
 for i, formation in enumerate(pitch.formations):
-    pitch.formation(formation, kind='scatter', color='black', s=350, ax=axes_p[i])
-    pitch.formation(formation, kind='text',
-                    positions=df_formations.loc[df_formations.formation == formation, 'name'],
-                    text=df_formations.loc[df_formations.formation == formation, 'name'],
-                    color='white', fontsize=8, ha='center', va='center', ax=axes_p[i])
+    pitch.formation(formation, kind="scatter", color="black", s=350, ax=axes_p[i])
+    pitch.formation(
+        formation,
+        kind="text",
+        positions=df_formations.loc[df_formations.formation == formation, "name"],
+        text=df_formations.loc[df_formations.formation == formation, "name"],
+        color="white",
+        fontsize=8,
+        ha="center",
+        va="center",
+        ax=axes_p[i],
+    )
     axes_p[i].set_title(formation, fontsize=10)
-axes['title'].axis('off')
-title = axes['title'].text(0.5, 0.5, 'Formations and positions', fontsize=35,
-                           ha='center', va='center')
+axes["title"].axis("off")
+title = axes["title"].text(
+    0.5, 0.5, "Formations and positions", fontsize=35, ha="center", va="center"
+)
 
 # remove spare axes
 number_spare_axes = (COLS * rows) - len(pitch.formations)

--- a/examples/pitch_plots/plot_grid.py
+++ b/examples/pitch_plots/plot_grid.py
@@ -51,24 +51,29 @@ fig, axs = pitch.grid(figheight=15, ncols=3)
 # ---------------
 # Here's how to plot a grid of pitches
 pitch = Pitch(linewidth=4)
-fig, axs = pitch.grid(nrows=3, ncols=4,  # number of rows/ columns
-                      figheight=25,  # the figure height in inches
-                      bottom=0.025,  # starts 2.5% in from the figure bottom
-                      # grid takes up 83% of the figure height
-                      # I calculated this so most of the figure is pitches
-                      # 1 - (bottom + endnote_height + endnote_space +
-                      # title_height + title_space) - 0.025 [space at top]
-                      grid_height=0.83,
-                      # reduced the amount of the figure height reserved
-                      # for the ax_endnote and ax_title since it is in
-                      # fractions of the figure height and the figure height
-                      # has increased. e.g. now the title_height is
-                      # 8% of the figheight (25).
-                      grid_width=0.95,  # the grid takes up 95% of the figwidth
-                      # 5% of the grid_height is the space between pitches.
-                      space=0.05,
-                      endnote_height=0.02, endnote_space=0.01,
-                      title_height=0.08, title_space=0.01)
+fig, axs = pitch.grid(
+    nrows=3,
+    ncols=4,  # number of rows/ columns
+    figheight=25,  # the figure height in inches
+    bottom=0.025,  # starts 2.5% in from the figure bottom
+    # grid takes up 83% of the figure height
+    # I calculated this so most of the figure is pitches
+    # 1 - (bottom + endnote_height + endnote_space +
+    # title_height + title_space) - 0.025 [space at top]
+    grid_height=0.83,
+    # reduced the amount of the figure height reserved
+    # for the ax_endnote and ax_title since it is in
+    # fractions of the figure height and the figure height
+    # has increased. e.g. now the title_height is
+    # 8% of the figheight (25).
+    grid_width=0.95,  # the grid takes up 95% of the figwidth
+    # 5% of the grid_height is the space between pitches.
+    space=0.05,
+    endnote_height=0.02,
+    endnote_space=0.01,
+    title_height=0.08,
+    title_space=0.01,
+)
 
 ##############################################################################
 # Removing the endnote/title
@@ -76,20 +81,24 @@ fig, axs = pitch.grid(nrows=3, ncols=4,  # number of rows/ columns
 # You can remove the endnote/title axis by setting the endnote_height/ title_height
 # to zero.
 pitch = Pitch(linewidth=4)
-fig, axs = pitch.grid(nrows=3, ncols=4,  # number of rows/ columns
-                      figheight=25,  # the figure height in inches
-                      bottom=0.025,  # starts 2.5% in from the figure bottom
-                      # increased the grid_height as no title/ endnote
-                      # now it takes up 95% of the figheight
-                      grid_height=0.95,
-                      grid_width=0.95,  # the grid takes up 95% of the figwidth
-                      # 6% of the grid_height is the space between pitches.
-                      space=0.06,
-                      # set the endnote/title height to zero so
-                      # they are not plotted. note this automatically
-                      # sets the endnote/title space to zero
-                      # so the grid starts at the bottom/left location
-                      endnote_height=0, title_height=0)
+fig, axs = pitch.grid(
+    nrows=3,
+    ncols=4,  # number of rows/ columns
+    figheight=25,  # the figure height in inches
+    bottom=0.025,  # starts 2.5% in from the figure bottom
+    # increased the grid_height as no title/ endnote
+    # now it takes up 95% of the figheight
+    grid_height=0.95,
+    grid_width=0.95,  # the grid takes up 95% of the figwidth
+    # 6% of the grid_height is the space between pitches.
+    space=0.06,
+    # set the endnote/title height to zero so
+    # they are not plotted. note this automatically
+    # sets the endnote/title space to zero
+    # so the grid starts at the bottom/left location
+    endnote_height=0,
+    title_height=0,
+)
 
 ##############################################################################
 # Pass maps
@@ -107,50 +116,84 @@ lineup = parser.lineup(15946)
 # Add on the subbed on/ off times to the lineup dataframe
 
 # dataframe with player_id and when they were subbed off
-time_off = events.loc[(events.type_name == 'Substitution'),
-                      ['player_id', 'minute']]
-time_off.rename({'minute': 'off'}, axis='columns', inplace=True)
+time_off = events.loc[(events.type_name == "Substitution"), ["player_id", "minute"]]
+time_off.rename({"minute": "off"}, axis="columns", inplace=True)
 # dataframe with player_id and when they were subbed on
-time_on = events.loc[(events.type_name == 'Substitution'),
-                     ['substitution_replacement_id', 'minute']]
-time_on.rename({'substitution_replacement_id': 'player_id',
-                'minute': 'on'}, axis='columns', inplace=True)
+time_on = events.loc[
+    (events.type_name == "Substitution"), ["substitution_replacement_id", "minute"]
+]
+time_on.rename(
+    {"substitution_replacement_id": "player_id", "minute": "on"},
+    axis="columns",
+    inplace=True,
+)
 players_on = time_on.player_id
 # merge on times subbed on/off
-lineup = lineup.merge(time_on, on='player_id', how='left')
-lineup = lineup.merge(time_off, on='player_id', how='left')
+lineup = lineup.merge(time_on, on="player_id", how="left")
+lineup = lineup.merge(time_off, on="player_id", how="left")
 
 ##############################################################################
 # Filter the lineup to include players who played and add on the first position they played
 
 # filter the tactics lineup for the starting xi
-starting_ids = events[events.type_name == 'Starting XI'].id
+starting_ids = events[events.type_name == "Starting XI"].id
 starting_xi = tactics[tactics.id.isin(starting_ids)]
 starting_players = starting_xi.player_id
 
 # filter the lineup for players that actually played
-mask_played = ((lineup.on.notnull()) | (lineup.off.notnull()) |
-               (lineup.player_id.isin(starting_players)))
+mask_played = (
+    (lineup.on.notnull())
+    | (lineup.off.notnull())
+    | (lineup.player_id.isin(starting_players))
+)
 lineup = lineup[mask_played].copy()
 
 # get the first position for each player and add this to the lineup dataframe
-player_positions = (events[['player_id', 'position_id']]
-                    .dropna(how='any', axis='rows')
-                    .drop_duplicates('player_id', keep='first'))
-lineup = lineup.merge(player_positions, how='left', on='player_id')
+player_positions = (
+    events[["player_id", "position_id"]]
+    .dropna(how="any", axis="rows")
+    .drop_duplicates("player_id", keep="first")
+)
+lineup = lineup.merge(player_positions, how="left", on="player_id")
 
 # add on the position abbreviation
-formation_dict = {1: 'GK', 2: 'RB', 3: 'RCB', 4: 'CB', 5: 'LCB', 6: 'LB', 7: 'RWB',
-                  8: 'LWB', 9: 'RDM', 10: 'CDM', 11: 'LDM', 12: 'RM', 13: 'RCM',
-                  14: 'CM', 15: 'LCM', 16: 'LM', 17: 'RW', 18: 'RAM', 19: 'CAM',
-                  20: 'LAM', 21: 'LW', 22: 'RCF', 23: 'ST', 24: 'LCF', 25: 'SS'}
-lineup['position_abbreviation'] = lineup.position_id.map(formation_dict)
+formation_dict = {
+    1: "GK",
+    2: "RB",
+    3: "RCB",
+    4: "CB",
+    5: "LCB",
+    6: "LB",
+    7: "RWB",
+    8: "LWB",
+    9: "RDM",
+    10: "CDM",
+    11: "LDM",
+    12: "RM",
+    13: "RCM",
+    14: "CM",
+    15: "LCM",
+    16: "LM",
+    17: "RW",
+    18: "RAM",
+    19: "CAM",
+    20: "LAM",
+    21: "LW",
+    22: "RCF",
+    23: "ST",
+    24: "LCF",
+    25: "SS",
+}
+lineup["position_abbreviation"] = lineup.position_id.map(formation_dict)
 
 # sort the dataframe so the players are
 # in the order of their position (if started), otherwise in the order they came on
-lineup['start'] = lineup.player_id.isin(starting_players)
-lineup.sort_values(['team_name', 'start', 'on', 'position_id'],
-                   ascending=[True, False, True, True], inplace=True)
+lineup["start"] = lineup.player_id.isin(starting_players)
+lineup.sort_values(
+    ["team_name", "start", "on", "position_id"],
+    ascending=[True, False, True, True],
+    inplace=True,
+)
 
 ##############################################################################
 # Filter the lineup/ events to one team and exclude some set pieces
@@ -162,12 +205,17 @@ team = team1
 lineup_team = lineup[lineup.team_name == team].copy()
 
 # filter the events to exclude some set pieces
-set_pieces = ['Throw-in', 'Free Kick', 'Corner', 'Kick Off', 'Goal Kick']
+set_pieces = ["Throw-in", "Free Kick", "Corner", "Kick Off", "Goal Kick"]
 # for the team pass map
-pass_receipts = events[(events.team_name == team) & (events.type_name == 'Ball Receipt')].copy()
+pass_receipts = events[
+    (events.team_name == team) & (events.type_name == "Ball Receipt")
+].copy()
 # for the player pass maps
-passes_excl_throw = events[(events.team_name == team) & (events.type_name == 'Pass') &
-                           (events.sub_type_name != 'Throw-in')].copy()
+passes_excl_throw = events[
+    (events.team_name == team)
+    & (events.type_name == "Pass")
+    & (events.sub_type_name != "Throw-in")
+].copy()
 
 # identify how many players played and how many subs were used
 # we will use this in the loop for only plotting pass maps for as
@@ -182,32 +230,48 @@ num_sub = num_players - 11
 pitch = Pitch(pad_top=10, line_zorder=2)
 
 # arrow properties for the sub on/off
-green_arrow = dict(arrowstyle='simple, head_width=0.7',
-                   connectionstyle="arc3,rad=-0.8", fc="green", ec="green")
-red_arrow = dict(arrowstyle='simple, head_width=0.7',
-                 connectionstyle="arc3,rad=-0.8", fc="red", ec="red")
+green_arrow = dict(
+    arrowstyle="simple, head_width=0.7",
+    connectionstyle="arc3,rad=-0.8",
+    fc="green",
+    ec="green",
+)
+red_arrow = dict(
+    arrowstyle="simple, head_width=0.7",
+    connectionstyle="arc3,rad=-0.8",
+    fc="red",
+    ec="red",
+)
 
 # a fontmanager object for using a google font
-fm_scada = FontManager('https://raw.githubusercontent.com/googlefonts/scada/main/fonts/ttf/'
-                       'Scada-Regular.ttf')
+fm_scada = FontManager(
+    "https://raw.githubusercontent.com/googlefonts/scada/main/fonts/ttf/"
+    "Scada-Regular.ttf"
+)
 
 # Load the Club/ Statsbomb logos
 # these are the property of the respective clubs/ StatsBomb.
-BARCA_LOGO_URL = ('https://upload.wikimedia.org/wikipedia/en/thumb/4/47/'
-                  'FC_Barcelona_%28crest%29.svg/142px-FC_Barcelona_%28crest%29.svg.png')
+BARCA_LOGO_URL = (
+    "https://upload.wikimedia.org/wikipedia/en/thumb/4/47/"
+    "FC_Barcelona_%28crest%29.svg/120px-FC_Barcelona_%28crest%29.svg.png"
+)
 request_barca = Request(BARCA_LOGO_URL)
-request_barca.add_header('User-Agent', 'mplsoccerdocs (https://mplsoccer.rtfd.io)')
+request_barca.add_header("User-Agent", "mplsoccerdocs (https://mplsoccer.rtfd.io)")
 barca_logo = Image.open(urlopen(request_barca))
 
-DEPORTIVO_LOGO_URL = ('https://upload.wikimedia.org/wikipedia/en/thumb/f/f8/'
-                      'Deportivo_Alaves_logo_%282020%29.svg/'
-                      '300px-Deportivo_Alaves_logo_%282020%29.svg.png')
+DEPORTIVO_LOGO_URL = (
+    "https://upload.wikimedia.org/wikipedia/en/thumb/f/f8/"
+    "Deportivo_Alaves_logo_%282020%29.svg/"
+    "250px-Deportivo_Alaves_logo_%282020%29.svg.png"
+)
 request_deportivo = Request(DEPORTIVO_LOGO_URL)
-request_deportivo.add_header('User-Agent', 'mplsoccerdocs (https://mplsoccer.rtfd.io)')
+request_deportivo.add_header("User-Agent", "mplsoccerdocs (https://mplsoccer.rtfd.io)")
 deportivo_logo = Image.open(urlopen(request_deportivo))
 
-SB_LOGO_URL = ('https://raw.githubusercontent.com/statsbomb/open-data/'
-               'master/img/SB%20-%20Icon%20Lockup%20-%20Colour%20positive.png')
+SB_LOGO_URL = (
+    "https://raw.githubusercontent.com/statsbomb/open-data/"
+    "master/img/SB%20-%20Icon%20Lockup%20-%20Colour%20positive.png"
+)
 sb_logo = Image.open(urlopen(SB_LOGO_URL))
 
 ##############################################################################
@@ -218,14 +282,20 @@ sb_logo = Image.open(urlopen(SB_LOGO_URL))
 warnings.simplefilter("ignore", UserWarning)
 
 # plot the 5 * 3 grid
-fig, axs = pitch.grid(nrows=5, ncols=3, figheight=30,
-                      endnote_height=0.03, endnote_space=0,
-                      # Turn off the endnote/title axis. I usually do this after
-                      # I am happy with the chart layout and text placement
-                      axis=False,
-                      title_height=0.08, grid_height=0.84)
+fig, axs = pitch.grid(
+    nrows=5,
+    ncols=3,
+    figheight=30,
+    endnote_height=0.03,
+    endnote_space=0,
+    # Turn off the endnote/title axis. I usually do this after
+    # I am happy with the chart layout and text placement
+    axis=False,
+    title_height=0.08,
+    grid_height=0.84,
+)
 # cycle through the grid axes and plot the player pass maps
-for idx, ax in enumerate(axs['pitch'].flat):
+for idx, ax in enumerate(axs["pitch"].flat):
     # only plot the pass maps up to the total number of players
     if idx < num_players:
         # filter the complete/incomplete passes for each player (excudes throw-ins)
@@ -236,12 +306,28 @@ for idx, ax in enumerate(axs['pitch'].flat):
         incomplete_pass = player_pass[player_pass.outcome_name.notnull()]
 
         # plot the arrows
-        pitch.arrows(complete_pass.x, complete_pass.y,
-                     complete_pass.end_x, complete_pass.end_y,
-                     color='#56ae6c', width=2, headwidth=4, headlength=6, ax=ax)
-        pitch.arrows(incomplete_pass.x, incomplete_pass.y,
-                     incomplete_pass.end_x, incomplete_pass.end_y,
-                     color='#7065bb', width=2, headwidth=4, headlength=6, ax=ax)
+        pitch.arrows(
+            complete_pass.x,
+            complete_pass.y,
+            complete_pass.end_x,
+            complete_pass.end_y,
+            color="#56ae6c",
+            width=2,
+            headwidth=4,
+            headlength=6,
+            ax=ax,
+        )
+        pitch.arrows(
+            incomplete_pass.x,
+            incomplete_pass.y,
+            incomplete_pass.end_x,
+            incomplete_pass.end_y,
+            color="#7065bb",
+            width=2,
+            headwidth=4,
+            headlength=6,
+            ax=ax,
+        )
 
         # plot the title for each player axis
         # here we use f-strings to combine the variables from the dataframe and text
@@ -253,74 +339,142 @@ for idx, ax in enumerate(axs['pitch'].flat):
         # We also use the highlight-text package to highlight complete_pass green
         # so put <> around the number of completed passes.
         total_pass = len(complete_pass) + len(incomplete_pass)
-        annotation_string = (f'{lineup_player.position_abbreviation} | '
-                             f'{lineup_player.player_name} | '
-                             f'<{len(complete_pass)}>/{total_pass} | '
-                             f'{round(100 * len(complete_pass)/total_pass, 1)}%')
-        ax_text(0, -5, annotation_string, ha='left', va='center', fontsize=13,
-                fontproperties=fm_scada.prop,  # using the fontmanager for the google font
-                highlight_textprops=[{"color": '#56ae6c'}], ax=ax)
+        annotation_string = (
+            f"{lineup_player.position_abbreviation} | "
+            f"{lineup_player.player_name} | "
+            f"<{len(complete_pass)}>/{total_pass} | "
+            f"{round(100 * len(complete_pass) / total_pass, 1)}%"
+        )
+        ax_text(
+            0,
+            -5,
+            annotation_string,
+            ha="left",
+            va="center",
+            fontsize=13,
+            fontproperties=fm_scada.prop,  # using the fontmanager for the google font
+            highlight_textprops=[{"color": "#56ae6c"}],
+            ax=ax,
+        )
 
         # add information for subsitutions on/off and arrows
         if not np.isnan(lineup_team.iloc[idx].off):
-            ax.text(116, -10, str(lineup_team.iloc[idx].off.astype(int)), fontsize=20,
-                    fontproperties=fm_scada.prop,
-                    ha='center', va='center')
-            ax.annotate('', (120, -2), (112, -2), arrowprops=red_arrow)
+            ax.text(
+                116,
+                -10,
+                str(lineup_team.iloc[idx].off.astype(int)),
+                fontsize=20,
+                fontproperties=fm_scada.prop,
+                ha="center",
+                va="center",
+            )
+            ax.annotate("", (120, -2), (112, -2), arrowprops=red_arrow)
         if not np.isnan(lineup_team.iloc[idx].on):
-            ax.text(104, -10, str(lineup_team.iloc[idx].on.astype(int)), fontsize=20,
-                    fontproperties=fm_scada.prop,
-                    ha='center', va='center')
-            ax.annotate('', (108, -2), (100, -2), arrowprops=green_arrow)
+            ax.text(
+                104,
+                -10,
+                str(lineup_team.iloc[idx].on.astype(int)),
+                fontsize=20,
+                fontproperties=fm_scada.prop,
+                ha="center",
+                va="center",
+            )
+            ax.annotate("", (108, -2), (100, -2), arrowprops=green_arrow)
 
 # plot on the last Pass Map
 # (note ax=ax as we have cycled through to the last axes in the loop)
-pitch.kdeplot(x=pass_receipts.x, y=pass_receipts.y, ax=ax,
-              cmap=cmr.lavender,
-              levels=100,
-              thresh=0, fill=True)
-ax.text(0, -5, f'{team}: Pass Receipt Heatmap', ha='left', va='center',
-        fontsize=20, fontproperties=fm_scada.prop)
+pitch.kdeplot(
+    x=pass_receipts.x,
+    y=pass_receipts.y,
+    ax=ax,
+    cmap=cmr.lavender,
+    levels=100,
+    thresh=0,
+    fill=True,
+)
+ax.text(
+    0,
+    -5,
+    f"{team}: Pass Receipt Heatmap",
+    ha="left",
+    va="center",
+    fontsize=20,
+    fontproperties=fm_scada.prop,
+)
 
 # remove unused axes (if any)
-for ax in axs['pitch'].flat[11 + num_sub:-1]:
+for ax in axs["pitch"].flat[11 + num_sub : -1]:
     ax.remove()
 
 # endnote text
-axs['endnote'].text(0, 0.5, 'The format is copied from @DymondFormation',
-                    fontsize=20, fontproperties=fm_scada.prop, va='center', ha='left')
+axs["endnote"].text(
+    0,
+    0.5,
+    "The format is copied from @DymondFormation",
+    fontsize=20,
+    fontproperties=fm_scada.prop,
+    va="center",
+    ha="left",
+)
 # to get the left position to align with the pitches I plotted it once with a random
 # left position (e.g. 0.5) and then used the following code
 # bbox_sb = ax_sb_logo.get_position()
 # bbox_endnote = axs['endnote'].get_position()
 # left = bbox_endnote.x1 - bbox_sb.width
-ax_sb_logo = add_image(sb_logo, fig, left=0.701126,
-                       # set the bottom and height to align with the endnote
-                       bottom=axs['endnote'].get_position().y0,
-                       height=axs['endnote'].get_position().height)
+ax_sb_logo = add_image(
+    sb_logo,
+    fig,
+    left=0.701126,
+    # set the bottom and height to align with the endnote
+    bottom=axs["endnote"].get_position().y0,
+    height=axs["endnote"].get_position().height,
+)
 
 # title text
-axs['title'].text(0.5, 0.65, f'{team1} Pass Maps vs {team2}', fontsize=40,
-                  fontproperties=fm_scada.prop, va='center', ha='center')
-SUB_TEXT = ('Player Pass Maps: exclude throw-ins only\n'
-            'Team heatmap: includes all attempted pass receipts')
-axs['title'].text(0.5, 0.35, SUB_TEXT, fontsize=20,
-                  fontproperties=fm_scada.prop, va='center', ha='center')
+axs["title"].text(
+    0.5,
+    0.65,
+    f"{team1} Pass Maps vs {team2}",
+    fontsize=40,
+    fontproperties=fm_scada.prop,
+    va="center",
+    ha="center",
+)
+SUB_TEXT = (
+    "Player Pass Maps: exclude throw-ins only\n"
+    "Team heatmap: includes all attempted pass receipts"
+)
+axs["title"].text(
+    0.5,
+    0.35,
+    SUB_TEXT,
+    fontsize=20,
+    fontproperties=fm_scada.prop,
+    va="center",
+    ha="center",
+)
 # plot logos (same height as the title_ax)
 # set the barca logo to align with the left/bottom of the title axes
-ax_barca_logo = add_image(barca_logo, fig,
-                          left=axs['title'].get_position().x0,
-                          bottom=axs['title'].get_position().y0,
-                          height=axs['title'].get_position().height)
+ax_barca_logo = add_image(
+    barca_logo,
+    fig,
+    left=axs["title"].get_position().x0,
+    bottom=axs["title"].get_position().y0,
+    height=axs["title"].get_position().height,
+)
 # set the deportivo logo to align with the right/bottom of the title axes
 # to get the left position to align with the pitches I plotted it once with a random
 # left position (e.g. 0.5) and then used the following code
 # bbox_logo = ax_deportivo_logo.get_position()
 # bbox_title = axs['title'].get_position()
 # left = bbox_title.x1 - bbox_logo.width
-ax_deportivo_logo = add_image(deportivo_logo, fig, left=0.8521,
-                              bottom=axs['title'].get_position().y0,
-                              height=axs['title'].get_position().height)
+ax_deportivo_logo = add_image(
+    deportivo_logo,
+    fig,
+    left=0.8521,
+    bottom=axs["title"].get_position().y0,
+    height=axs["title"].get_position().height,
+)
 # setting this example to the gallery thumbnail
 # sphinx_gallery_thumbnail_path = 'gallery/pitch_plots/images/sphx_glr_plot_grid_005'
 

--- a/examples/speedometer/README.rst
+++ b/examples/speedometer/README.rst
@@ -1,0 +1,9 @@
+Speedometer Charts
+==================
+
+These examples show how to use the ``Speedometer`` class to create
+speedometer/gauge visualizations for player speed metrics and other
+performance indicators.
+
+The speedometer chart implementation is inspired by
+`znstrider's speedo library <https://github.com/znstrider/speedo>`_.

--- a/examples/speedometer/plot_speedometer_basic.py
+++ b/examples/speedometer/plot_speedometer_basic.py
@@ -1,0 +1,124 @@
+"""
+==================
+Speedometer Charts
+==================
+
+* ``mplsoccer``, ``speedometer`` module helps plot speedometer/gauge charts.
+
+* The speedometer chart is inspired by `znstrider's speedo library
+  <https://github.com/znstrider/speedo>`_.
+
+* Speedometer charts are useful for displaying player speed metrics,
+  performance scores, or any single value within a defined range.
+
+Here we will show some examples of how to use ``mplsoccer`` to plot speedometer charts.
+"""
+
+from mplsoccer import Speedometer
+import matplotlib.pyplot as plt
+
+##############################################################################
+# Basic Speedometer
+# -----------------
+# The simplest speedometer just needs a start value, end value, and the current value.
+
+speedo = Speedometer(start_value=0, end_value=12)
+fig, ax = speedo.draw(value=8.5)
+plt.show()
+
+##############################################################################
+# Player Sprint Speed
+# -------------------
+# A more realistic example showing a player's sprint speed with title and units.
+
+speedo = Speedometer(
+    start_value=0,
+    end_value=12,
+    title="Sprint Speed",
+    unit=" m/s",
+    title_fontsize=14,
+    annotation_fontsize=14,
+)
+fig, ax = speedo.draw(value=9.2, figsize=(6, 4))
+plt.show()
+
+##############################################################################
+# Custom Colors
+# -------------
+# You can customize the color gradient of the speedometer.
+
+speedo = Speedometer(
+    start_value=0,
+    end_value=100,
+    colors=["#2ecc71", "#f1c40f", "#e74c3c"],  # Green -> Yellow -> Red
+    segments_per_color=8,
+    title="Performance Score",
+    unit="%",
+)
+fig, ax = speedo.draw(value=72)
+plt.show()
+
+##############################################################################
+# Different Angle Range
+# ---------------------
+# Change the start and end angles to create different arc shapes.
+
+speedo = Speedometer(
+    start_value=0,
+    end_value=10,
+    start_angle=0,
+    end_angle=180,
+    title="Half-Circle Gauge",
+)
+fig, ax = speedo.draw(value=7)
+plt.show()
+
+##############################################################################
+# Multiple Speedometers
+# ---------------------
+# Create multiple speedometers in a grid layout.
+
+fig, axes = plt.subplots(1, 3, figsize=(15, 5))
+
+players = [
+    ("Mbappé", 9.8),
+    ("Haaland", 9.2),
+    ("Salah", 8.9),
+]
+
+for ax, (name, speed) in zip(axes, players):
+    speedo = Speedometer(
+        start_value=7,
+        end_value=11,
+        title=name,
+        unit=" m/s",
+        title_fontsize=12,
+        annotation_fontsize=12,
+        label_fontsize=6,
+    )
+    speedo.draw(value=speed, ax=ax)
+
+fig.suptitle("Top Sprint Speeds", fontsize=16, fontweight='bold')
+plt.tight_layout()
+plt.show()
+
+##############################################################################
+# Dark Theme
+# ----------
+# Speedometer on a dark background.
+
+fig, ax = plt.subplots(figsize=(6, 5), facecolor='#1a1a2e')
+ax.set_facecolor('#1a1a2e')
+
+speedo = Speedometer(
+    start_value=0,
+    end_value=100,
+    colors=["#e94560", "#f39c12", "#16a085"],
+    title="Match Rating",
+    title_fontcolor='white',
+    label_fontcolor='white',
+    annotation_fontcolor='white',
+    arc_edgecolor='#1a1a2e',
+)
+speedo.draw(value=78, ax=ax)
+plt.show()

--- a/mplsoccer/__init__.py
+++ b/mplsoccer/__init__.py
@@ -15,3 +15,4 @@ from .utils import *
 from .bumpy_chart import *
 from .py_pizza import *
 from .grid import *
+from .speedometer import *

--- a/mplsoccer/speedometer.py
+++ b/mplsoccer/speedometer.py
@@ -1,0 +1,454 @@
+"""A Python module for plotting speedometer charts.
+
+Author: Adapted for mplsoccer by PGupta-Git
+Original speedo library by @znstrider (https://github.com/znstrider/speedo)
+
+The speedometer chart is useful for displaying player speed metrics
+and other performance indicators in a visually intuitive gauge format.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.patches import Circle, Wedge
+
+__all__ = ["Speedometer"]
+
+
+def _degree_range(n, start=0, end=180):
+    """Calculate start/end angles and midpoints for n segments.
+    
+    Parameters
+    ----------
+    n : int
+        Number of segments.
+    start : float, default 0
+        Start angle in degrees.
+    end : float, default 180
+        End angle in degrees.
+    
+    Returns
+    -------
+    tuple
+        (angle_ranges, midpoints) where angle_ranges is Nx2 array of start/end angles
+        and midpoints is array of segment midpoint angles.
+    """
+    start_ = np.linspace(start, end, n + 1, endpoint=True)[:-1]
+    end_ = np.linspace(start, end, n + 1, endpoint=True)[1:]
+    mid_points = start_ + ((end_ - start_) / 2.0)
+    return np.c_[start_, end_], mid_points
+
+
+def _rotate(angle):
+    """Convert angle for label rotation."""
+    return np.degrees(np.radians(angle) * np.pi / np.pi - np.radians(90))
+
+
+class Speedometer:
+    """A class for plotting speedometer charts in Matplotlib.
+
+    Parameters
+    ----------
+    start_value : float
+        Start of the range of values (minimum value on the gauge).
+    end_value : float
+        End of the range of values (maximum value on the gauge).
+    center : tuple, default (0, 0)
+        (x, y) position of the speedometer center.
+    radius : float, default 4
+        Radius of the speedometer.
+    width_ratio : float, default 0.25
+        Ratio of wedge width to radius.
+    colors : list, default None
+        List of colors for the wedge segments. If None, uses a default
+        red-yellow-green-blue gradient: ["#d7191c", "#fdae61", "#ffffbf", "#abd9e9", "#2c7bb6"]
+    segments_per_color : int, default 5
+        Number of segments per color in the gradient.
+    start_angle : float, default -30
+        Start angle of the speedometer arc in degrees.
+    end_angle : float, default 210
+        End angle of the speedometer arc in degrees.
+    arc_edgecolor : str, default None
+        Edge color for the wedges. If None, uses the axis background color.
+    fade_alpha : float, default 0.25
+        Alpha value for wedges beyond the current value.
+    patch_lw : float, default 0.25
+        Line width between wedges.
+    snap_to_pos : bool, default False
+        Whether to snap the arrow to the center of a wedge.
+    unit : str, default ''
+        Unit string to display with the value annotation.
+    label_fontsize : int, default 7
+        Font size for value labels around the arc.
+    label_fontcolor : str, default None
+        Color for the value labels. If None, uses matplotlib default.
+    draw_labels : bool, default True
+        Whether to draw value labels around the arc.
+    labels : list, default None
+        Custom labels for the arc. If None, uses evenly spaced values.
+    rotate_labels : bool, default False
+        Whether to rotate value labels to follow the arc.
+    title : str, default None
+        Title to display above the speedometer.
+    title_fontsize : int, default 18
+        Font size for the title.
+    title_fontcolor : str, default None
+        Color for the title text. If None, uses matplotlib default.
+    title_facecolor : str, default None
+        Background color for the title bbox. If None, uses axis background.
+    title_edgecolor : str, default None
+        Edge color for the title bbox. If None, uses axis background.
+    title_offset : float, default 1.5
+        Offset of title above the speedometer as a factor of radius.
+    title_pad : float, default 1
+        Padding around the title bbox.
+    draw_annotation : bool, default True
+        Whether to draw the value annotation below the speedometer.
+    annotation_fontsize : int, default 16
+        Font size for the value annotation.
+    annotation_fontcolor : str, default None
+        Color for the annotation text. If None, uses matplotlib default.
+    annotation_facecolor : str, default None
+        Background color for the annotation bbox. If None, uses axis background.
+    annotation_edgecolor : str, default None
+        Edge color for the annotation bbox. If None, uses axis background.
+    annotation_offset : float, default 0.75
+        Offset of annotation below the speedometer as a factor of radius.
+    annotation_pad : float, default 0
+        Padding around the annotation bbox.
+    fade_hatch : str, default None
+        Hatch pattern for faded wedges (e.g., 'xxx').
+    """
+
+    def __init__(
+        self,
+        start_value,
+        end_value,
+        center=(0, 0),
+        radius=4,
+        width_ratio=0.25,
+        colors=None,
+        segments_per_color=5,
+        start_angle=-30,
+        end_angle=210,
+        arc_edgecolor=None,
+        fade_alpha=0.25,
+        patch_lw=0.25,
+        snap_to_pos=False,
+        unit='',
+        label_fontsize=7,
+        label_fontcolor=None,
+        draw_labels=True,
+        labels=None,
+        rotate_labels=False,
+        title=None,
+        title_fontsize=18,
+        title_fontcolor=None,
+        title_facecolor=None,
+        title_edgecolor=None,
+        title_offset=1.5,
+        title_pad=1,
+        draw_annotation=True,
+        annotation_fontsize=16,
+        annotation_fontcolor=None,
+        annotation_facecolor=None,
+        annotation_edgecolor=None,
+        annotation_offset=0.75,
+        annotation_pad=0,
+        fade_hatch=None,
+    ):
+        # Validation
+        if end_value <= start_value:
+            raise ValueError("end_value must be greater than start_value")
+        if colors is not None and len(colors) == 0:
+            raise ValueError("colors list cannot be empty")
+        if radius <= 0:
+            raise ValueError("radius must be positive")
+
+        self.start_value = start_value
+        self.end_value = end_value
+        self.center = center
+        self.radius = radius
+        self.width_ratio = width_ratio
+        self.colors = colors if colors is not None else [
+            "#d7191c", "#fdae61", "#ffffbf", "#abd9e9", "#2c7bb6"
+        ]
+        self.segments_per_color = segments_per_color
+        self.start_angle = start_angle
+        self.end_angle = end_angle
+        self.arc_edgecolor = arc_edgecolor
+        self.fade_alpha = fade_alpha
+        self.patch_lw = patch_lw
+        self.snap_to_pos = snap_to_pos
+        self.unit = unit
+        self.label_fontsize = label_fontsize
+        self.label_fontcolor = label_fontcolor
+        self.draw_labels = draw_labels
+        self.labels = labels
+        self.rotate_labels = rotate_labels
+        self.title = title
+        self.title_fontsize = title_fontsize
+        self.title_fontcolor = title_fontcolor
+        self.title_facecolor = title_facecolor
+        self.title_edgecolor = title_edgecolor
+        self.title_offset = title_offset
+        self.title_pad = title_pad
+        self.draw_annotation = draw_annotation
+        self.annotation_fontsize = annotation_fontsize
+        self.annotation_fontcolor = annotation_fontcolor
+        self.annotation_facecolor = annotation_facecolor
+        self.annotation_edgecolor = annotation_edgecolor
+        self.annotation_offset = annotation_offset
+        self.annotation_pad = annotation_pad
+        self.fade_hatch = fade_hatch
+
+        # Computed properties
+        self.n_colors = len(self.colors)
+        self._expanded_colors = np.repeat(self.colors, self.segments_per_color)
+        self._n_segments = self.segments_per_color * self.n_colors
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}("
+            f"start_value={self.start_value}, "
+            f"end_value={self.end_value}, "
+            f"center={self.center}, "
+            f"radius={self.radius}, "
+            f"start_angle={self.start_angle}, "
+            f"end_angle={self.end_angle})"
+        )
+
+    def draw(self, value, ax=None, figsize=(8, 6)):
+        """Draw the speedometer chart.
+
+        Parameters
+        ----------
+        value : float
+            The current value to display on the speedometer.
+        ax : matplotlib.axes.Axes, default None
+            Axes to draw on. If None, creates a new figure and axes.
+        figsize : tuple, default (8, 6)
+            Figure size in inches (width, height). Only used when ax is None.
+
+        Returns
+        -------
+        tuple or None
+            If ax is None, returns (fig, ax). Otherwise returns None.
+        """
+        return_fig_ax = ax is None
+        if ax is None:
+            fig, ax = plt.subplots(figsize=figsize)
+        else:
+            fig = ax.figure
+
+        # Resolve colors that depend on axis
+        arc_edgecolor = self.arc_edgecolor or ax.get_facecolor()
+        label_fontcolor = self.label_fontcolor or plt.rcParams.get(
+            'axes.labelcolor', 'black'
+        )
+        title_fontcolor = self.title_fontcolor or plt.rcParams.get(
+            'axes.labelcolor', 'black'
+        )
+        title_facecolor = self.title_facecolor or ax.get_facecolor()
+        title_edgecolor = self.title_edgecolor or ax.get_facecolor()
+        annotation_fontcolor = self.annotation_fontcolor or plt.rcParams.get(
+            'axes.labelcolor', 'black'
+        )
+        annotation_facecolor = self.annotation_facecolor or ax.get_facecolor()
+        annotation_edgecolor = self.annotation_edgecolor or ax.get_facecolor()
+
+        # Compute value positions
+        midpoint_values = np.linspace(
+            self.start_value, self.end_value, self._n_segments, endpoint=True
+        )
+        edge_values = np.linspace(
+            self.start_value, self.end_value, self._n_segments + 1, endpoint=True
+        )
+
+        arrow_index = np.argmin(np.abs(midpoint_values - value))
+        arrow_value = midpoint_values[arrow_index]
+
+        # Compute angles
+        angle_range, midpoints = _degree_range(
+            self._n_segments, start=self.start_angle, end=self.end_angle
+        )
+        annotation_angles = np.concatenate([angle_range[:, 0], angle_range[-1:, 1]])
+
+        # Build labels
+        if self.labels is None:
+            labels = ['' for _ in range(self._n_segments + 1)]
+            for i, label_val in zip(
+                range(0, self._n_segments + 1, self.segments_per_color),
+                np.linspace(self.start_value, self.end_value, self.n_colors + 1, endpoint=True)
+            ):
+                labels[i] = label_val
+        else:
+            labels = self.labels
+
+        # Draw wedges
+        patches = []
+        for ang, color, edge_val in zip(
+            angle_range, self._expanded_colors, edge_values[-2::-1]
+        ):
+            if arrow_value <= edge_val:
+                alpha = self.fade_alpha
+                hatch = self.fade_hatch
+            else:
+                alpha = 1
+                hatch = None
+
+            # Main wedge with color
+            patches.append(
+                Wedge(
+                    self.center,
+                    self.radius,
+                    *ang,
+                    width=self.width_ratio * self.radius,
+                    facecolor=color,
+                    edgecolor=arc_edgecolor,
+                    lw=self.patch_lw,
+                    alpha=alpha,
+                    hatch=hatch,
+                )
+            )
+            # Edge-only wedge for clean borders
+            patches.append(
+                Wedge(
+                    self.center,
+                    self.radius,
+                    *ang,
+                    width=self.width_ratio * self.radius,
+                    facecolor='None',
+                    edgecolor=arc_edgecolor,
+                    lw=self.patch_lw,
+                )
+            )
+
+        for patch in patches:
+            ax.add_patch(patch)
+
+        # Draw labels
+        if self.draw_labels:
+            for angle, label in zip(annotation_angles, labels[-1::-1]):
+                if self.rotate_labels:
+                    radius_factor = 0.625
+                    adj = 90 if angle < 90 else -90
+                else:
+                    radius_factor = 0.65
+                    adj = 180 if (angle < 0) or (angle > 180) else 0
+
+                # Format label - handle floating point precision
+                if isinstance(label, (float, np.floating)):
+                    # Round to avoid floating point display issues
+                    label_rounded = round(label, 10)
+                    if label_rounded == int(label_rounded):
+                        label = int(label_rounded)
+                    else:
+                        # Format to reasonable precision (max 2 decimal places)
+                        label = round(label_rounded, 2)
+
+                ax.text(
+                    self.center[0] + radius_factor * self.radius * np.cos(np.radians(angle)),
+                    self.center[1] + radius_factor * self.radius * np.sin(np.radians(angle)),
+                    label,
+                    horizontalalignment='center',
+                    verticalalignment='center',
+                    fontsize=self.label_fontsize,
+                    fontweight='bold',
+                    color=label_fontcolor,
+                    rotation=_rotate(angle) + adj,
+                    bbox={'facecolor': arc_edgecolor, 'ec': 'None', 'pad': 0},
+                    zorder=10,
+                )
+
+        # Calculate arrow angle
+        if self.snap_to_pos:
+            arrow_angle = midpoints[-1::-1][arrow_index - len(self._expanded_colors)]
+        else:
+            deg_range = self.end_angle - self.start_angle
+            val_range = self.end_value - self.start_value
+            arrow_angle = self.end_angle - (value - self.start_value) / val_range * deg_range
+
+        # Draw arrow
+        ax.arrow(
+            *self.center,
+            0.825 * self.radius * np.cos(np.radians(arrow_angle)),
+            0.825 * self.radius * np.sin(np.radians(arrow_angle)),
+            width=self.radius / 20,
+            head_width=self.radius / 10,
+            head_length=self.radius / 15,
+            fc=ax.get_facecolor(),
+            ec=label_fontcolor,
+            zorder=9,
+            lw=2,
+        )
+
+        # Draw center circle
+        ax.add_patch(
+            Circle(
+                self.center,
+                radius=self.radius / 20,
+                facecolor=ax.get_facecolor(),
+                edgecolor=label_fontcolor,
+                lw=2.5,
+                zorder=10,
+            )
+        )
+
+        # Draw annotation
+        if self.draw_annotation:
+            annotation_text = f'{value}{self.unit}'
+            ax.text(
+                self.center[0],
+                self.center[1] - self.annotation_offset * self.radius,
+                annotation_text,
+                horizontalalignment='center',
+                verticalalignment='center',
+                fontsize=self.annotation_fontsize,
+                fontweight='bold',
+                color=annotation_fontcolor,
+                bbox={
+                    'facecolor': annotation_facecolor,
+                    'edgecolor': annotation_edgecolor,
+                    'pad': self.annotation_pad,
+                },
+                zorder=11,
+            )
+
+        # Draw title
+        if self.title is not None:
+            ax.text(
+                self.center[0],
+                self.center[1] + self.title_offset * self.radius,
+                self.title,
+                horizontalalignment='center',
+                verticalalignment='center',
+                fontsize=self.title_fontsize,
+                fontweight='bold',
+                color=title_fontcolor,
+                bbox={
+                    'facecolor': title_facecolor,
+                    'edgecolor': title_edgecolor,
+                    'pad': self.title_pad,
+                },
+                zorder=11,
+            )
+
+        # Set axis properties
+        ax.set_aspect('equal')
+        margin = self.radius * 0.3
+        ax.set_xlim(
+            self.center[0] - self.radius - margin,
+            self.center[0] + self.radius + margin
+        )
+        ax.set_ylim(
+            self.center[1] - self.radius - margin,
+            self.center[1] + self.radius + margin
+        )
+        ax.axis('off')
+
+        if return_fig_ax:
+            return fig, ax
+        return None
+
+    # __str__ is the same as __repr__
+    __str__ = __repr__

--- a/tests/test_speedometer.py
+++ b/tests/test_speedometer.py
@@ -1,0 +1,145 @@
+"""Tests for the Speedometer class."""
+
+import matplotlib.pyplot as plt
+import pytest
+
+from mplsoccer import Speedometer
+
+
+class TestSpeedometer:
+    """Tests for Speedometer class."""
+
+    def test_speedometer_creation(self):
+        """Test basic instantiation without errors."""
+        speedo = Speedometer(start_value=0, end_value=10)
+        assert speedo.start_value == 0
+        assert speedo.end_value == 10
+        assert speedo.radius == 4  # default value
+
+    def test_speedometer_draw_returns_fig_ax(self):
+        """Test that draw() returns (fig, ax) when ax=None."""
+        speedo = Speedometer(start_value=0, end_value=10)
+        result = speedo.draw(value=5)
+        assert result is not None
+        assert len(result) == 2
+        fig, ax = result
+        assert isinstance(fig, plt.Figure)
+        assert hasattr(ax, 'plot')  # verify it's an axes object
+        plt.close(fig)
+
+    def test_speedometer_draw_with_ax(self):
+        """Test that draw(ax=ax) returns None."""
+        speedo = Speedometer(start_value=0, end_value=10)
+        fig, ax = plt.subplots()
+        result = speedo.draw(value=5, ax=ax)
+        assert result is None
+        plt.close(fig)
+
+    def test_speedometer_value_bounds(self):
+        """Test values at min/max/out-of-range don't crash."""
+        speedo = Speedometer(start_value=0, end_value=10)
+        
+        # Value at minimum
+        fig, ax = speedo.draw(value=0)
+        plt.close(fig)
+        
+        # Value at maximum
+        fig, ax = speedo.draw(value=10)
+        plt.close(fig)
+        
+        # Value below minimum
+        fig, ax = speedo.draw(value=-5)
+        plt.close(fig)
+        
+        # Value above maximum
+        fig, ax = speedo.draw(value=15)
+        plt.close(fig)
+
+    def test_speedometer_custom_colors(self):
+        """Test custom color list works."""
+        custom_colors = ["#ff0000", "#00ff00", "#0000ff"]
+        speedo = Speedometer(
+            start_value=0,
+            end_value=10,
+            colors=custom_colors
+        )
+        assert speedo.colors == custom_colors
+        assert speedo.n_colors == 3
+        
+        fig, ax = speedo.draw(value=5)
+        plt.close(fig)
+
+    def test_speedometer_repr(self):
+        """Test __repr__ returns string."""
+        speedo = Speedometer(start_value=0, end_value=10)
+        repr_str = repr(speedo)
+        assert isinstance(repr_str, str)
+        assert "Speedometer" in repr_str
+        assert "start_value=0" in repr_str
+        assert "end_value=10" in repr_str
+
+    def test_speedometer_with_title_and_unit(self):
+        """Test speedometer with title and unit."""
+        speedo = Speedometer(
+            start_value=0,
+            end_value=12,
+            title="Player Speed",
+            unit=" m/s"
+        )
+        fig, ax = speedo.draw(value=8.5)
+        plt.close(fig)
+
+    def test_speedometer_custom_angles(self):
+        """Test custom start and end angles."""
+        speedo = Speedometer(
+            start_value=0,
+            end_value=10,
+            start_angle=0,
+            end_angle=180
+        )
+        assert speedo.start_angle == 0
+        assert speedo.end_angle == 180
+        
+        fig, ax = speedo.draw(value=5)
+        plt.close(fig)
+
+    def test_speedometer_no_labels(self):
+        """Test speedometer without labels."""
+        speedo = Speedometer(
+            start_value=0,
+            end_value=10,
+            draw_labels=False
+        )
+        fig, ax = speedo.draw(value=5)
+        plt.close(fig)
+
+    def test_speedometer_no_annotation(self):
+        """Test speedometer without annotation."""
+        speedo = Speedometer(
+            start_value=0,
+            end_value=10,
+            draw_annotation=False
+        )
+        fig, ax = speedo.draw(value=5)
+        plt.close(fig)
+
+    def test_speedometer_invalid_range(self):
+        """Test that invalid range raises ValueError."""
+        with pytest.raises(ValueError, match="end_value must be greater than start_value"):
+            Speedometer(start_value=10, end_value=5)
+        
+        with pytest.raises(ValueError, match="end_value must be greater than start_value"):
+            Speedometer(start_value=5, end_value=5)
+
+    def test_speedometer_empty_colors(self):
+        """Test that empty colors list raises ValueError."""
+        with pytest.raises(ValueError, match="colors list cannot be empty"):
+            Speedometer(start_value=0, end_value=10, colors=[])
+
+    def test_speedometer_invalid_radius(self):
+        """Test that non-positive radius raises ValueError."""
+        with pytest.raises(ValueError, match="radius must be positive"):
+            Speedometer(start_value=0, end_value=10, radius=0)
+        
+        with pytest.raises(ValueError, match="radius must be positive"):
+            Speedometer(start_value=0, end_value=10, radius=-1)


### PR DESCRIPTION
Implements Issue #16 - Add speedometer plots from znstrider/speedo library.

Features:
- Speedometer class with configurable value ranges, colors, and angles
- Support for titles, units, and annotations
- Works standalone or with existing matplotlib axes
- Follows mplsoccer API patterns (like PyPizza)

Includes:
- Core module: mplsoccer/speedometer.py
- Unit tests: tests/test_speedometer.py
- Gallery example: examples/speedometer/

Credits: Original speedo library by @znstrider