### PR TITLE
Fix docs build: Wikimedia thumbnail sizes and kloppy to_df

### DIFF
--- a/examples/pitch_plots/plot_formations.py
+++ b/examples/pitch_plots/plot_formations.py
@@ -273,9 +273,9 @@ totw_player_data
 # Get the club badges as a dictionary and turn it into a list of badges for each player.
 badge_urls = {
     'Manchester United': 'https://upload.wikimedia.org/wikipedia/en/thumb/7/7a/Manchester_United_FC_crest.svg/250px-Manchester_United_FC_crest.svg.png',
-    'Chelsea': 'https://upload.wikimedia.org/wikipedia/en/thumb/c/cc/Chelsea_FC.svg/240px-Chelsea_FC.svg.png',
+    'Chelsea': 'https://upload.wikimedia.org/wikipedia/en/thumb/c/cc/Chelsea_FC.svg/250px-Chelsea_FC.svg.png',
     'Manchester City': 'https://upload.wikimedia.org/wikipedia/en/thumb/e/eb/Manchester_City_FC_badge.svg/250px-Manchester_City_FC_badge.svg.png',
-    'Reading': 'https://upload.wikimedia.org/wikipedia/en/thumb/1/11/Reading_FC.svg/240px-Reading_FC.svg.png',
+    'Reading': 'https://upload.wikimedia.org/wikipedia/en/thumb/1/11/Reading_FC.svg/250px-Reading_FC.svg.png',
     'Arsenal': "https://upload.wikimedia.org/wikipedia/en/thumb/5/53/Arsenal_FC.svg/250px-Arsenal_FC.svg.png",
 }
 image_dict = {}

--- a/examples/pitch_plots/plot_grid.py
+++ b/examples/pitch_plots/plot_grid.py
@@ -194,14 +194,14 @@ fm_scada = FontManager('https://raw.githubusercontent.com/googlefonts/scada/main
 # Load the Club/ Statsbomb logos
 # these are the property of the respective clubs/ StatsBomb.
 BARCA_LOGO_URL = ('https://upload.wikimedia.org/wikipedia/en/thumb/4/47/'
-                  'FC_Barcelona_%28crest%29.svg/142px-FC_Barcelona_%28crest%29.svg.png')
+                  'FC_Barcelona_%28crest%29.svg/120px-FC_Barcelona_%28crest%29.svg.png')
 request_barca = Request(BARCA_LOGO_URL)
 request_barca.add_header('User-Agent', 'mplsoccerdocs (https://mplsoccer.rtfd.io)')
 barca_logo = Image.open(urlopen(request_barca))
 
 DEPORTIVO_LOGO_URL = ('https://upload.wikimedia.org/wikipedia/en/thumb/f/f8/'
                       'Deportivo_Alaves_logo_%282020%29.svg/'
-                      '300px-Deportivo_Alaves_logo_%282020%29.svg.png')
+                      '250px-Deportivo_Alaves_logo_%282020%29.svg.png')
 request_deportivo = Request(DEPORTIVO_LOGO_URL)
 request_deportivo.add_header('User-Agent', 'mplsoccerdocs (https://mplsoccer.rtfd.io)')
 deportivo_logo = Image.open(urlopen(request_deportivo))

--- a/examples/pitch_plots/plot_standardize.py
+++ b/examples/pitch_plots/plot_standardize.py
@@ -121,11 +121,10 @@ parser = Sbopen()
 df_statsbomb = parser.event(7579)[0]  # events are the zero index
 
 dataset = wyscout.load_open_data(match_id=2058002, coordinates='wyscout')
-df_wyscout = dataset.to_pandas(
-        additional_columns={
-            'player_name': lambda event: str(event.player),
-            'team_name': lambda event: str(event.player.team)
-        },
+df_wyscout = dataset.to_df(
+        '*',
+        player_name=lambda event: str(event.player),
+        team_name=lambda event: str(event.player.team),
     ) 
 
 ##############################################################################


### PR DESCRIPTION
Fixes three example failures currently breaking the Read the Docs build.

- **`plot_grid.py` / `plot_formations.py`**: Wikimedia now only serves a fixed set of thumbnail widths to hotlink clients (HTTP 400 `Use thumbnail sizes listed on https://w.wiki/GHai`). The off-menu widths (142px/240px/300px) are changed to allowed sizes (120px/250px). **This fix is by @PGupta-Git** — it was originally part of their curved radar labels PR; extracted here (with commit authorship) so the docs build is repaired independently of that feature.
- **`plot_standardize.py`**: the docs environment installs kloppy unpinned, and recent kloppy removed `EventDataset.to_pandas` in favour of `to_df`. Ported to `to_df('*', ...)`, verified against kloppy 3.19.0.